### PR TITLE
Fix bug in DS3231 initialization

### DIFF
--- a/src/mgos_ds3231.c
+++ b/src/mgos_ds3231.c
@@ -190,10 +190,14 @@ struct mgos_ds3231 *mgos_ds3231_create(uint8_t addr) {
   ds->_addr = addr;
   ds->_i2c = i2c;
   // init the DS3231
-  // Setup the clock to make sure that it is running, that the oscillator and
-  // square wave are disabled, and that alarm interrupts are disabled
-  mgos_i2c_write_reg_b(i2c, addr, DS3231_REG_CONTROL, 0x00);
-  mgos_ds3231_disable_alarms(ds);
+  // init the DS3231
+  // Set the chip to an initial known state (the power-on defaults): oscillator
+  // enabled, battery-backed square wave disabled, ~INT/SQW output set to 
+  // interrupt function and both alarm interrupts disabled
+  mgos_i2c_write_reg_b(i2c, addr, DS3231_REG_CONTROL, 0x1C);
+  // No need to call mgos_i2c_disable_alarms, since they will already be 
+  // disabled by the code above
+  //mgos_ds3231_disable_alarms(ds);
   return ds;
 }
 


### PR DESCRIPTION
There is a bug in the initialization function that, depending on how the chip is wired up (eg, attaching the DS3231~INT pin to your processor ~RST to have the chip reset - or wake - your processor), may put your processor on an infinite boot loop.

The bug is due to the control flags being set up with bad defaults (they were also not in accordance with the part datasheet), which caused the ~INT pin reverting to a square wave output that constantly reboots the main processor. See attached file (blue is reset signal and yellow in the initial ESP8266 boot message).
![newfile1](https://user-images.githubusercontent.com/5495377/50842935-e7de6780-134e-11e9-9211-29fecf347ebd.png)
