### PR TITLE
Correct bug in device init that may put it on an interrupt reassertion loop

### DIFF
--- a/src/mgos_ds3231.c
+++ b/src/mgos_ds3231.c
@@ -193,6 +193,10 @@ struct mgos_ds3231 *mgos_ds3231_create(uint8_t addr) {
   // Setup the clock to make sure that it is running, that the oscillator and
   // square wave are disabled, and that alarm interrupts are disabled
   mgos_i2c_write_reg_b(i2c, addr, DS3231_REG_CONTROL, 0x00);
+  // If we are seting up a new mgos_ds3231 instance, it makes sense to clear
+  // any previous interrupt flag that is pending, to prevent it from being 
+  // reasserted when the device is (re)initialized.
+  mgos_ds3231_check_alarms(ds);
   mgos_ds3231_disable_alarms(ds);
   return ds;
 }


### PR DESCRIPTION
In the current version of the code, when the mgos_ds3231 struct is initialized, it doesn't clear any previous asserted alarm interrupts on the relevant register. So when the DS3231 is (re) initialized, it immediately assert a new interrupt. One would normally be able to handle it in code, but for the people using the ~INT output to wake their processor from deep-sleep with a reset, that would mean a very cumbersome and hacky solution.

In the proposed solution, since the DS3231 is (re) initialized when the startup code calls mgos_ds3231_create(), it makes sense to just make sure there are no previous interrupts pending. It doesn't matter for a fresh boot of the device, and prevents the reassertion loop on subsequent reboots.